### PR TITLE
COMP: Fix locally defined but not used warnings

### DIFF
--- a/PETTumorSegmentation/Logic/itkOSFGraphToMeshFilter.txx
+++ b/PETTumorSegmentation/Logic/itkOSFGraphToMeshFilter.txx
@@ -124,7 +124,6 @@ void
 OSFGraphToMeshFilter<TInputOSFGraph,TOutputMesh>
 ::CopyInputOSFSurfaceToOutputMeshPoints(typename InputOSFGraphType::OSFSurface::ConstPointer osfSurface, OutputMeshPointer mesh)
 {
-  typedef typename OutputMeshType::PointType PointType;
   typename OutputMeshType::PointsContainerPointer points = OutputMeshType::PointsContainer::New();
   points->Reserve( osfSurface->GetNumberOfVertices() );
   typename OutputMeshType::PointsContainer::Iterator pointIterator = points->Begin();

--- a/PETTumorSegmentation/Logic/itkSealingSegmentationMergerImageFilter.txx
+++ b/PETTumorSegmentation/Logic/itkSealingSegmentationMergerImageFilter.txx
@@ -67,7 +67,6 @@ SealingSegmentationMergerImageFilter<TInputImage, TUptakeImage, TOutputImage>
 {
   (void) threadId; // mute unused parameter warning; we use outputRegionForThread instead of threadId
   typedef itk::ConstNeighborhoodIterator<InputImageType> InputNeighborhoodIteratorType;
-  typedef itk::ImageRegionConstIterator<InputImageType> InputIteratorType;
   typedef itk::ImageRegionIterator<UptakeImageType> UptakeIteratorType;
   typedef itk::ImageRegionIterator<OutputImageType> OutputIteratorType;
   

--- a/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx
+++ b/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx
@@ -600,9 +600,6 @@ std::vector<valueType>
 vtkSlicerPETTumorSegmentationLogic::SampleColumnPoints(int vertexId, vtkMRMLPETTumorSegmentationParametersNode* node, typename ImageInterpolatorType::Pointer interpolator, valueType defaultValue)
 {
   //Copy all the uptake values interpolated on the column's nodes into a vector.
-  typedef OSFSurfaceType::CoordinateType Coordinate;
-  typedef OSFSurfaceType::VertexIdentifier VertexIdentifier;
-  typedef OSFSurfaceType::ColumnPositionIdentifier ColumnPositionIdentifier;
   typedef OSFSurfaceType::ColumnCoordinatesContainer ColumnCoordinatesContainer;
   
   ColumnCoordinatesContainer::ConstPointer columnCoordinates = node->GetOSFGraph()->GetSurface()->GetColumnCoordinates( vertexId );
@@ -1003,7 +1000,6 @@ vtkSlicerPETTumorSegmentationLogic::ScalarImageType::Pointer vtkSlicerPETTumorSe
   
   // resample image; default interpolation is linear, which is what we want here
   typedef itk::ResampleImageFilter<ScalarImageType, ScalarImageType> ResamplerType;
-  typedef itk::IdentityTransform< ScalarImageType::PixelType, 3> IdentityTransformType;
   ResamplerType::Pointer resampler = ResamplerType::New();
   resampler->SetInput( petSubVolume );
   resampler->SetSize(size);
@@ -1027,9 +1023,6 @@ void vtkSlicerPETTumorSegmentationLogic::GenerateWatershedImages(vtkMRMLPETTumor
   invertedImage->SetOrigin(petSubVolume->GetOrigin());
   invertedImage->SetSpacing(petSubVolume->GetSpacing());
   invertedImage->Allocate();
-
-  typedef itk::ImageRegionIterator<DoubleImageType> DataIteratorType;
-  typedef itk::ImageRegionIteratorWithIndex<DoubleImageType> DataIteratorTypeWithIndex;
   
   itk::ImageRegionIterator<ScalarImageType> datIt(petSubVolume, petSubVolume->GetLargestPossibleRegion());
   itk::ImageRegionIteratorWithIndex<DoubleImageType>  idatIt(invertedImage, invertedImage->GetLargestPossibleRegion());
@@ -1138,7 +1131,6 @@ void vtkSlicerPETTumorSegmentationLogic::BuildColumnForVertex(int vertexId, vtkM
   OSFSurfaceType::Pointer surface =  node->GetOSFGraph()->GetSurface();  
   typedef OSFSurfaceType::CoordinateType Coordinate;
   typedef OSFSurfaceType::ColumnCoordinatesContainer ColumnCoordinatesContainer;
-  typedef OSFSurfaceType::ColumnCostsContainer ColumnCostsContainer;
 
   //Create the new container of appropriate size
   int numberOfSteps = (int) std::ceil(meshSphereRadius); //TODO Should this be meshSphereRadius/columnStepSize? As it is, it assumes columnStepSize==1, which for now it does, but still might be worth modifying for future use.


### PR DESCRIPTION
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/itkOSFGraphToMeshFilter.txx:127:46: warning: typedef ‘PointType’ locally defined but not used [-Wunused-local-typedefs]
   typedef typename OutputMeshType::PointType PointType;
                                              ^
In file included from /home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/itkSealingSegmentationMergerImageFilter.h:139:0,
                 from /home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:71:
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/itkSealingSegmentationMergerImageFilter.txx: In member function ‘void itk::SealingSegmentationMergerImageFilter<TInputImage, TUptakeImage, TOutputImage>::ThreadedGenerateData(const OutputImageRegionType&, itk::ThreadIdType)’:
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/itkSealingSegmentationMergerImageFilter.txx:70:57: warning: typedef ‘InputIteratorType’ locally defined but not used [-Wunused-local-typedefs]
   typedef itk::ImageRegionConstIterator<InputImageType> InputIteratorType;
                                                                                                                      ^
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx: In static member function ‘static std::vector<valueType> vtkSlicerPETTumorSegmentationLogic::SampleColumnPoints(int, vtkMRMLPETTumorSegmentationParametersNode_, typename ImageInterpolatorType::Pointer, valueType)’:
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:603:42: warning: typedef ‘Coordinate’ locally defined but not used [-Wunused-local-typedefs]
   typedef OSFSurfaceType::CoordinateType Coordinate;
                                          ^
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:604:44: warning: typedef ‘VertexIdentifier’ locally defined but not used [-Wunused-local-typedefs]
   typedef OSFSurfaceType::VertexIdentifier VertexIdentifier;
                                            ^
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:605:52: warning: typedef ‘ColumnPositionIdentifier’ locally defined but not used [-Wunused-local-typedefs]
   typedef OSFSurfaceType::ColumnPositionIdentifier ColumnPositionIdentifier;
                                                    ^
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx: In member function ‘itk::Image<float, 3u>::Pointer vtkSlicerPETTumorSegmentationLogic::ExtractPETSubVolumeIsotropic(vtkMRMLPETTumorSegmentationParametersNode_, itk::Image<float, 3u>::Pointer)’:
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:1006:66: warning: typedef ‘IdentityTransformType’ locally defined but not used [-Wunused-local-typedefs]
   typedef itk::IdentityTransform< ScalarImageType::PixelType, 3> IdentityTransformType;
                                                                  ^
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx: In member function ‘void vtkSlicerPETTumorSegmentationLogic::GenerateWatershedImages(vtkMRMLPETTumorSegmentationParametersNode_, itk::Image<float, 3u>::Pointer)’:
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:1031:53: warning: typedef ‘DataIteratorType’ locally defined but not used [-Wunused-local-typedefs]
   typedef itk::ImageRegionIterator<DoubleImageType> DataIteratorType;
                                                     ^
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:1032:62: warning: typedef ‘DataIteratorTypeWithIndex’ locally defined but not used [-Wunused-local-typedefs]
   typedef itk::ImageRegionIteratorWithIndex<DoubleImageType> DataIteratorTypeWithIndex;
                                                              ^
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx: In static member function ‘static void vtkSlicerPETTumorSegmentationLogic::BuildColumnForVertex(int, vtkMRMLPETTumorSegmentationParametersNode_)’:
/home/jcfr/Projects/PETTumorSegmentation/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx:1141:48: warning: typedef ‘ColumnCostsContainer’ locally defined but not used [-Wunused-local-typedefs]
   typedef OSFSurfaceType::ColumnCostsContainer ColumnCostsContainer;
                                                ^
