### PR TITLE
STYLE: Remove unneeded PETTumorSegmentationParametersNode Reset method.

### DIFF
--- a/PETTumorSegmentation/MRML/vtkMRMLPETTumorSegmentationParametersNode.cxx
+++ b/PETTumorSegmentation/MRML/vtkMRMLPETTumorSegmentationParametersNode.cxx
@@ -40,7 +40,7 @@ vtkMRMLPETTumorSegmentationParametersNode::vtkMRMLPETTumorSegmentationParameters
   this->DenoiseThreshold = false;
   this->LinearCost = false;
   this->NecroticRegion = false;
-  Reset();
+  this->OSFGraph = NULL;
 }
 
 //----------------------------------------------------------------------------
@@ -51,13 +51,6 @@ vtkMRMLPETTumorSegmentationParametersNode::~vtkMRMLPETTumorSegmentationParameter
   this->SetGlobalRefinementIndicatorListReference ( NULL );
   this->SetLocalRefinementIndicatorListReference ( NULL );
   this->SetSegmentationVolumeReference ( NULL );
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLPETTumorSegmentationParametersNode::Reset()
-{
-  OSFGraph = NULL;
-  Histogram.clear();
 }
 
 //----------------------------------------------------------------------------

--- a/PETTumorSegmentation/MRML/vtkMRMLPETTumorSegmentationParametersNode.h
+++ b/PETTumorSegmentation/MRML/vtkMRMLPETTumorSegmentationParametersNode.h
@@ -51,8 +51,6 @@ class VTK_SLICER_PETTUMORSEGMENTATION_MODULE_MRML_EXPORT vtkMRMLPETTumorSegmenta
   static vtkMRMLPETTumorSegmentationParametersNode *New();
   vtkTypeMacro(vtkMRMLPETTumorSegmentationParametersNode, vtkMRMLNode);
   void PrintSelf(ostream& os, vtkIndent indent);
-  
-  void Reset();
 
   // Description:
   // Create instance


### PR DESCRIPTION
Since by default, the method Reset defined in vtkMRMLNode ends up
instantiating a new node and calling Copy, all "attributes" are
automatically "reset" during that process and the method Reset don't
need to be redefined.
