### PR TITLE
10 editor undoredo hook

### DIFF
--- a/PETTumorSegmentation/Logic/logismos_graph.hxx
+++ b/PETTumorSegmentation/Logic/logismos_graph.hxx
@@ -103,7 +103,7 @@ private:
   /// \brief Set node as active and add it to active node queue.
   inline void activate(node* p_node)
   {
-    assert(!p_node);
+    assert(p_node);
     if(p_node->is_active() == false){
       p_node->set_active(true);
       m_active_nodes.push_back(p_node);


### PR DESCRIPTION
    ENH: avoid hard-coding access to buttons for undo/redo
    
    Uses observers to trigger internal undo/redo state management
    rather than connecting to signals from the buttons.
    
    Requires this change to Slicer core:
    
    https://github.com/Slicer/Slicer/pull/862

Also:

  BUG: fix assert that caused false positive exit in debug mode.