### PR TITLE
COMP: fixes for ITK 5 build errors

### DIFF
--- a/PETTumorSegmentation/Logic/itkWorkers.txx
+++ b/PETTumorSegmentation/Logic/itkWorkers.txx
@@ -28,7 +28,7 @@ Workers::Workers(int numWorkers) :
 m_MultiThreader(MultiThreader::New())
 {
   m_NumWorkers = std::max(1, std::min(numWorkers, int(m_MultiThreader->MultiThreaderBase::GetGlobalMaximumNumberOfThreads())));
-  m_MultiThreader->SetNumberOfThreads(m_NumWorkers);
+  m_MultiThreader->SetNumberOfWorkUnits(m_NumWorkers);
 }
 
 //----------------------------------------------------------------------------
@@ -52,9 +52,9 @@ template <class T>
 ITK_THREAD_RETURN_TYPE Workers::RunMethodCB(void* arg)
 {
   struct UserData{Workers* workers; T* object; void(T::*method)(int, int);};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   ((data->object)->*(data->method))(workerId,numWorkers);
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
@@ -75,9 +75,9 @@ template <class T, typename T1>
 ITK_THREAD_RETURN_TYPE Workers::RunMethodCB(void* arg)
 {
   struct UserData{Workers* workers; T* object; void(T::*method)(int, int, T1); T1 p1;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   ((data->object)->*(data->method))(workerId,numWorkers, data->p1);
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
@@ -98,9 +98,9 @@ template <class T>
 ITK_THREAD_RETURN_TYPE Workers::RunConstMethodCB(void* arg)
 {
   struct UserData{Workers* workers; T* object; void(T::*method)(int, int) const;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   ((data->object)->*(data->method))(workerId,numWorkers);
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
@@ -119,9 +119,9 @@ void Workers::RunFunction(void(*function)(int, int))
 ITK_THREAD_RETURN_TYPE Workers::RunFunctionCB(void* arg)
 {
   struct UserData{Workers* workers; void(*method)(int, int);};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   (data->method)(workerId,numWorkers);
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
@@ -142,9 +142,9 @@ template <typename T1>
 ITK_THREAD_RETURN_TYPE Workers::RunFunctionCB(void* arg)
 {
   struct UserData{Workers* workers; void(*method)(int, int, T1); T1 p1;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   (data->method)(workerId,numWorkers, data->p1);
   return ITK_THREAD_RETURN_DEFAULT_VALUE;
@@ -165,9 +165,9 @@ template <typename RangeType>
 ITK_THREAD_RETURN_TYPE Workers::RunFunctionForRangeCB(void* arg)
 {
   struct UserData{Workers* workers; void(*method)(RangeType); RangeType min; RangeType max;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   RangeType currentValue = (data->min)+RangeType(workerId);
   while (currentValue<=data->max)
@@ -193,9 +193,9 @@ template <typename RangeType, typename T1>
 ITK_THREAD_RETURN_TYPE Workers::RunFunctionForRangeCB(void* arg)
 {
   struct UserData{Workers* workers; void(*method)(RangeType, T1); RangeType min; RangeType max; T1 p1;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   RangeType currentValue = (data->min)+RangeType(workerId);
   while (currentValue<=data->max)
@@ -221,9 +221,9 @@ template <typename RangeType, typename T1, typename T2, typename T3>
 ITK_THREAD_RETURN_TYPE Workers::RunFunctionForRangeCB(void* arg)
 {
   struct UserData{Workers* workers; void(*method)(RangeType, T1, T2, T3); RangeType min; RangeType max; T1 p1; T2 p2; T3 p3;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   RangeType currentValue = (data->min)+RangeType(workerId);
   while (currentValue<=data->max)
@@ -249,9 +249,9 @@ template <typename RangeType, typename T1, typename T2,  typename T3, typename T
 ITK_THREAD_RETURN_TYPE Workers::RunFunctionForRangeCB(void* arg)
 {
   struct UserData{Workers* workers; void(*method)(RangeType, T1, T2, T3, T4 p4, T5 p5); RangeType min; RangeType max; T1 p1; T2 p2; T3 p3; T4 p4; T5 p5;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   RangeType currentValue = (data->min)+RangeType(workerId);
   while (currentValue<=data->max)
@@ -277,9 +277,9 @@ template <typename RangeType, typename T1,  typename T2,  typename T3, typename 
 ITK_THREAD_RETURN_TYPE Workers::RunFunctionForRangeCB(void* arg)
 {
   struct UserData{Workers* workers; void(*method)(RangeType, T1, T2, T3, T4 p4, T5 p5, T6 p6); RangeType min; RangeType max; T1 p1; T2 p2; T3 p3; T4 p4; T5 p5; T6 p6;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   RangeType currentValue = (data->min)+RangeType(workerId);
   while (currentValue<=data->max)
@@ -305,9 +305,9 @@ template <class T, typename RangeType>
 ITK_THREAD_RETURN_TYPE Workers::RunMethodForRangeCB(void* arg)
 {
   struct UserData{Workers* workers; T* object; void(*method)(RangeType); RangeType min; RangeType max;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   RangeType currentValue = (data->min)+RangeType(workerId);
   while (currentValue<=data->max)
@@ -333,9 +333,9 @@ template <class T, typename RangeType, typename T1>
 ITK_THREAD_RETURN_TYPE Workers::RunMethodForRangeCB(void* arg)
 {
   struct UserData{Workers* workers; T* object; void(*method)(RangeType); RangeType min; RangeType max; T1 p1;};
-  typename MultiThreader::ThreadInfoStruct* threadInfo = (typename MultiThreader::ThreadInfoStruct *)( arg );
-  int workerId = threadInfo->ThreadID;
-  int numWorkers = threadInfo->NumberOfThreads;
+  typename MultiThreader::WorkUnitInfo* threadInfo = (typename MultiThreader::WorkUnitInfo *)( arg );
+  int workerId = threadInfo->WorkUnitID;
+  int numWorkers = threadInfo->NumberOfWorkUnits;
   UserData* data = (UserData*)(threadInfo->UserData);
   RangeType currentValue = (data->min)+RangeType(workerId);
   while (currentValue<=data->max)

--- a/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx
+++ b/PETTumorSegmentation/Logic/vtkSlicerPETTumorSegmentationLogic.cxx
@@ -138,7 +138,7 @@ void vtkSlicerPETTumorSegmentationLogic::Apply(vtkMRMLPETTumorSegmentationParame
       node->SetInitialLabelMap(this->ConvertSegmentationToITK(node));
     initialLabelMap = resampleNN<LabelImageType,ScalarImageType>(node->GetInitialLabelMap(), petVolume);
   }
-  itkDebugMacro(node->WriteTXT("seg_init.txt"));
+  vtkDebugMacro(;node->WriteTXT("seg_init.txt"));
 
   //If from a click, there will be a new finger print.  If not, update the finger print.
   if (!this->CheckFingerPrint(node))
@@ -154,7 +154,7 @@ void vtkSlicerPETTumorSegmentationLogic::Apply(vtkMRMLPETTumorSegmentationParame
     //Create the segmentation and apply it to the label map.
     FinalizeOSFSegmentation(node, petVolume, initialLabelMap);
   }
-  itkDebugMacro(node->WriteTXT("seg_final.txt"));
+  vtkDebugMacro(;node->WriteTXT("seg_final.txt"));
 }
 
 //----------------------------------------------------------------------------
@@ -169,7 +169,7 @@ void vtkSlicerPETTumorSegmentationLogic::ApplyGlobalRefinement(vtkMRMLPETTumorSe
     initialLabelMap = ConvertLabelImageToITK(node, labelImageData);
   else // for use with Segment Editor
     initialLabelMap = resampleNN<LabelImageType,ScalarImageType>(node->GetInitialLabelMap(), petVolume);
-  itkDebugMacro(node->WriteTXT("global_refinement_init.txt"));
+  vtkDebugMacro(;node->WriteTXT("global_refinement_init.txt"));
 
   node->SetOSFGraph( Clone(node->GetOSFGraph()) ); // we manipulate graph costs directly; therefore, we need to clone the initial graph to ensure correct undo/redo behavior
   UpdateGraphCostsGlobally(node, petVolume, initialLabelMap); //Sets the cost for all nodes by threshold.  New threshold is determined inside.
@@ -177,7 +177,7 @@ void vtkSlicerPETTumorSegmentationLogic::ApplyGlobalRefinement(vtkMRMLPETTumorSe
   UpdateGraphCostsLocally(node, petVolume, true); //Reapplies all local refinement, since older points' effects are lost when global update changes base cost.
   FinalizeOSFSegmentation(node, petVolume, initialLabelMap);  //Applies the changed label map
 
-  itkDebugMacro(node->WriteTXT("global_refinement_final.txt"));
+  vtkDebugMacro(;node->WriteTXT("global_refinement_final.txt"));
 }
 
 //----------------------------------------------------------------------------
@@ -192,13 +192,13 @@ void vtkSlicerPETTumorSegmentationLogic::ApplyLocalRefinement(vtkMRMLPETTumorSeg
     initialLabelMap = ConvertLabelImageToITK(node, labelImageData);
   else // for use with Segment Editor
     initialLabelMap = resampleNN<LabelImageType,ScalarImageType>(node->GetInitialLabelMap(), petVolume);
-  itkDebugMacro(node->WriteTXT("local_refinement_init.txt"));
+  vtkDebugMacro(;node->WriteTXT("local_refinement_init.txt"));
 
   node->SetOSFGraph( Clone(node->GetOSFGraph()) ); // we manipulate graph costs directly; therefore, we need to clone the initial graph to ensure correct undo/redo behavior
   UpdateGraphCostsLocally(node, petVolume); //Add effect of most recent refinement point only
 
   FinalizeOSFSegmentation(node, petVolume, initialLabelMap);  //Applies the changed label map
-  itkDebugMacro(node->WriteTXT("local_refinement_final.txt"));
+  vtkDebugMacro(;node->WriteTXT("local_refinement_final.txt"));
 }
 
 //----------------------------------------------------------------------------

--- a/PETTumorSegmentation/MRML/vtkMRMLPETTumorSegmentationParametersNode.cxx
+++ b/PETTumorSegmentation/MRML/vtkMRMLPETTumorSegmentationParametersNode.cxx
@@ -260,7 +260,7 @@ void vtkMRMLPETTumorSegmentationParametersNode::ReadXMLAttributes(const char** a
 void vtkMRMLPETTumorSegmentationParametersNode::WriteTXT(const char* filename)
 {
   vtkMRMLScene* slicerMrmlScene = qSlicerApplication::application()->mrmlScene();
-  ofstream outfile;
+  std::ofstream outfile;
   outfile.open (filename);
   outfile << "Writing this to a file.\n";
   outfile << "Label="<<Label<<"\n"; // short Label;


### PR DESCRIPTION
* prefix ofstream with std:: since std namespace is no longer
exposed by default
* change from Thread to WorkUnit methods for multithreading
* switch from itkDebugMacro to vtkDebugMacro since it is called
from a vtk class and itk's macro now assumes itkObject methods
(note this usage requires unusual semicolon in the macro
call but this is not a syntax error)

See:
https://github.com/InsightSoftwareConsortium/ITK/blob/4ce3383a469c3d9db0b9cf9a48897bf24c4b3128/Documentation/ITK5MigrationGuide.md